### PR TITLE
Make plan criteria fully editable before approval

### DIFF
--- a/hireright-app/app/(app)/jobs/[id]/page.tsx
+++ b/hireright-app/app/(app)/jobs/[id]/page.tsx
@@ -42,20 +42,41 @@ export default async function JobPage({ params }: { params: { id: string } }) {
           <form action={updatePlan}>
             <input type="hidden" name="planId" value={plan.planId} />
 
-            <h3 style={{ margin: "1rem 0 .5rem" }}>Criteria</h3>
+            <h3 style={{ margin: "1rem 0 .5rem" }}>Criteria <span className="muted small">(fully editable — the AI&apos;s draft is a starting point)</span></h3>
             <table>
-              <thead><tr><th>Requirement</th><th>Type</th><th>Weight</th><th>Knockout</th></tr></thead>
+              <thead><tr><th>Requirement</th><th>Type</th><th>Weight</th><th>Knockout</th><th>Remove</th></tr></thead>
               <tbody>
                 {plan.criteria.map((c) => (
                   <tr key={c.id}>
-                    <td style={{ fontWeight: 600 }}>{c.label}</td>
-                    <td><span className={`badge ${c.kind === "must_have" ? "amber" : "gray"}`}>{c.kind === "must_have" ? "Must" : "Nice"}</span></td>
+                    <td><input type="text" name={`label_${c.id}`} defaultValue={c.label} style={{ width: "100%", minWidth: 220 }} /></td>
+                    <td>
+                      <select name={`kind_${c.id}`} defaultValue={c.kind}>
+                        <option value="must_have">Must</option>
+                        <option value="nice_to_have">Nice</option>
+                      </select>
+                    </td>
                     <td><input type="number" step="0.01" min="0" max="1" name={`weight_${c.id}`} defaultValue={c.weight} style={{ width: 80 }} /></td>
                     <td><input type="checkbox" name={`knockout_${c.id}`} defaultChecked={c.isKnockout} /></td>
+                    <td><input type="checkbox" name={`remove_${c.id}`} title="Remove this criterion on save" /></td>
                   </tr>
                 ))}
+                <tr>
+                  <td><input type="text" name="new_label" placeholder="+ Add a requirement (e.g. 5+ years Python)" style={{ width: "100%", minWidth: 220 }} /></td>
+                  <td>
+                    <select name="new_kind" defaultValue="must_have">
+                      <option value="must_have">Must</option>
+                      <option value="nice_to_have">Nice</option>
+                    </select>
+                  </td>
+                  <td><input type="number" step="0.01" min="0" max="1" name="new_weight" defaultValue={0.1} style={{ width: 80 }} /></td>
+                  <td><input type="checkbox" name="new_knockout" /></td>
+                  <td />
+                </tr>
               </tbody>
             </table>
+            <p className="muted small" style={{ marginTop: ".4rem" }}>
+              Edit any requirement text, switch Must/Nice, tick Remove to drop a row, or fill the last row to add one — then <strong>Save edits</strong>. Renaming a requirement re-derives what the screener looks for.
+            </p>
 
             <h3 style={{ margin: "1.5rem 0 .5rem" }}>Interview blueprint <span className="muted small">(editable)</span></h3>
             {plan.interviewBlueprint.map((q, i) => (

--- a/hireright-app/app/actions.ts
+++ b/hireright-app/app/actions.ts
@@ -8,7 +8,8 @@ import { logAudit } from "@/lib/audit";
 import { getAI, ACTIVE_PROVIDER } from "@/lib/ai";
 import { uid, nowISO } from "@/lib/ids";
 import { extractText, deriveSkills, guessName } from "@/lib/ingestion/parse";
-import { Job, Interview, Scorecard, ClientAction, ActionType } from "@/lib/types";
+import { deriveKeywords } from "@/lib/ai/mock";
+import { Job, Interview, Scorecard, ClientAction, ActionType, Criterion } from "@/lib/types";
 
 // ── Auth ──────────────────────────────────────────────────────────────
 export async function login() {
@@ -88,12 +89,48 @@ export async function updatePlan(formData: FormData) {
   if (!plan || plan.status !== "draft") return;
 
   plan.cutoffValue = cutoffValue;
+
+  // Edit existing criteria (label, type, weight, knockout) and collect
+  // removals. Renaming a criterion re-derives its scoring keywords, so the
+  // screener actually matches on the new requirement rather than the old one.
+  const removed: string[] = [];
   plan.criteria.forEach((c) => {
+    if (formData.get(`remove_${c.id}`) === "on") {
+      removed.push(c.id);
+      return;
+    }
+    const lbl = formData.get(`label_${c.id}`);
+    if (lbl !== null && String(lbl).trim() && String(lbl).trim() !== c.label) {
+      c.label = String(lbl).trim();
+      c.keywords = deriveKeywords(c.label);
+    }
+    const kind = formData.get(`kind_${c.id}`);
+    if (kind === "must_have" || kind === "nice_to_have") c.kind = kind;
     const w = formData.get(`weight_${c.id}`);
     const ko = formData.get(`knockout_${c.id}`);
     if (w !== null) c.weight = Math.max(0, Math.min(1, Number(w)));
     c.isKnockout = ko === "on";
   });
+  // Apply removals — but never leave a plan with zero criteria.
+  if (removed.length && removed.length < plan.criteria.length) {
+    plan.criteria = plan.criteria.filter((c) => !removed.includes(c.id));
+  }
+
+  // Add a new criterion if the blank row was filled in.
+  const newLabel = String(formData.get("new_label") || "").trim();
+  if (newLabel) {
+    const newKind = formData.get("new_kind") === "nice_to_have" ? "nice_to_have" : "must_have";
+    const nc: Criterion = {
+      id: uid("crit"),
+      label: newLabel,
+      weight: Math.max(0, Math.min(1, Number(formData.get("new_weight") || 0.1))),
+      isKnockout: formData.get("new_knockout") === "on",
+      kind: newKind,
+      keywords: deriveKeywords(newLabel)
+    };
+    plan.criteria.push(nc);
+  }
+
   plan.interviewBlueprint.forEach((q) => {
     const t = formData.get(`q_${q.id}`);
     if (t !== null && String(t) !== q.text) {
@@ -109,7 +146,7 @@ export async function updatePlan(formData: FormData) {
     action: "plan.edited",
     entityType: "plan",
     entityId: planId,
-    rationale: "Client edited criteria weights / interview questions."
+    rationale: "Client edited plan criteria (labels/type/weights/knockouts, add/remove) and/or interview questions."
   });
   revalidatePath(`/jobs/${plan.jobId}`);
 }

--- a/hireright-app/lib/ai/mock.ts
+++ b/hireright-app/lib/ai/mock.ts
@@ -230,7 +230,7 @@ function findSentence(text: string, keywords: string[]): string | null {
 }
 
 // ── helpers ───────────────────────────────────────────────────────────
-function deriveKeywords(label: string): string[] {
+export function deriveKeywords(label: string): string[] {
   const low = label.toLowerCase();
   const hits = SKILL_LEXICON.filter((s) => low.includes(s));
   if (hits.length) return Array.from(new Set(hits));


### PR DESCRIPTION
Follow-up to the merged Hireright PR. Lets the human reviewer fully edit the AI-drafted closure plan before approving it — the requirement text and type were previously read-only.

## What changed
- Criteria **label** is now an editable text input; **type** is a Must/Nice dropdown
- Per-row **Remove** checkbox, plus a blank add-row to append a new requirement
- `updatePlan` applies edits, removals (never leaving zero criteria), and additions
- Renaming a requirement **re-derives its scoring keywords**, so the screener matches the new requirement rather than the stale one

## Why
With real Claude (`AI_PROVIDER=anthropic`) the drafted criteria are strong; with the deterministic mock they can be weak (generic lexicon words). Either way the client should have full control of the plan before it becomes the immutable, approved basis for screening.

Build clean, 32 invariant tests pass, CI green on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB)_