### PR TITLE
Fix: newly-created job 404s (FileRepo stale cache)

### DIFF
--- a/hireright-app/lib/db/file.ts
+++ b/hireright-app/lib/db/file.ts
@@ -13,18 +13,28 @@ const DB_PATH = path.join(DATA_DIR, "db.json");
 
 export class FileRepo implements Repo {
   private cache: DB | null = null;
+  private mtimeMs = 0;
 
+  // Re-read from disk whenever the file has changed since we last read it.
+  // Next.js can instantiate this module more than once (server actions vs.
+  // RSC renders in dev, separate bundles), so a write from one instance must
+  // be visible to reads from another — otherwise a just-created job 404s.
   private load(): DB {
-    if (this.cache) return this.cache;
     if (fs.existsSync(DB_PATH)) {
-      const db = JSON.parse(fs.readFileSync(DB_PATH, "utf8")) as DB;
-      // Backfill arrays added after a store was first written, so older
-      // db.json files keep working across upgrades.
-      db.candidateUsers ??= [];
-      db.applications ??= [];
-      db.mockInterviews ??= [];
-      this.cache = db;
-    } else {
+      const { mtimeMs } = fs.statSync(DB_PATH);
+      if (!this.cache || mtimeMs !== this.mtimeMs) {
+        const db = JSON.parse(fs.readFileSync(DB_PATH, "utf8")) as DB;
+        // Backfill arrays added after a store was first written, so older
+        // db.json files keep working across upgrades.
+        db.candidateUsers ??= [];
+        db.applications ??= [];
+        db.mockInterviews ??= [];
+        this.cache = db;
+        this.mtimeMs = mtimeMs;
+      }
+      return this.cache;
+    }
+    if (!this.cache) {
       this.cache = seedDB();
       this.persist();
     }
@@ -34,6 +44,7 @@ export class FileRepo implements Repo {
   private persist() {
     if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
     fs.writeFileSync(DB_PATH, JSON.stringify(this.cache, null, 2), "utf8");
+    this.mtimeMs = fs.statSync(DB_PATH).mtimeMs; // don't re-read our own write
   }
 
   private mutate<T>(fn: (db: DB) => T): T {

--- a/hireright-app/test/filerepo.test.ts
+++ b/hireright-app/test/filerepo.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import { FileRepo } from "@/lib/db/file";
+import type { Job } from "@/lib/types";
+
+// Regression: a job created through one FileRepo instance must be visible to a
+// second instance (Next.js can run server actions and RSC renders against
+// different module instances). Before the mtime-reload fix, the reader's cache
+// was loaded once at startup and never refreshed, so a just-created job 404'd.
+
+const DATA_DIR = path.join(process.cwd(), ".data");
+const DB_PATH = path.join(DATA_DIR, "db.json");
+
+function job(id: string): Job {
+  return {
+    id,
+    clientId: "client_demo",
+    title: "Test Role",
+    jdText: "Requirements: Strong Python.",
+    stage: "JD_UPLOADED",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    createdBy: "user_demo"
+  };
+}
+
+describe("FileRepo — cross-instance consistency", () => {
+  beforeEach(() => {
+    if (fs.existsSync(DB_PATH)) fs.rmSync(DB_PATH);
+  });
+  afterEach(() => {
+    if (fs.existsSync(DB_PATH)) fs.rmSync(DB_PATH);
+  });
+
+  it("a job created in one instance is visible to another instance", async () => {
+    const reader = new FileRepo();
+    await reader.snapshot(); // reader caches the seed (no job yet)
+
+    const writer = new FileRepo();
+    await writer.createJob(job("job_x"));
+
+    const db = await reader.snapshot(); // must re-read from disk
+    expect(db.jobs.some((j) => j.id === "job_x")).toBe(true);
+  });
+
+  it("a candidate portal user created elsewhere is found by email", async () => {
+    const writer = new FileRepo();
+    await writer.snapshot();
+    const reader = new FileRepo();
+    await reader.snapshot();
+
+    await writer.createCandidateUser({
+      id: "cu1",
+      name: "Jo",
+      email: "jo@x.co",
+      resumeText: "Python",
+      skills: ["python"],
+      createdAt: "2026-08-01T00:00:00.000Z"
+    });
+
+    expect(await reader.candidateUserByEmail("jo@x.co")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Symptom
Creating a role and landing on `/jobs/<id>` returned **"This page could not be found"**, even though the job was created.

## Root cause
`createJob()` persists the job to disk before redirecting, so the data is there. But `FileRepo` cached the DB in memory once and never re-read it. Next.js can execute the server action and the RSC page render against **different module instances**, so the render instance held a stale cache from startup and never saw the just-written job → `notFound()`.

## Fix
`FileRepo.load()` now re-reads `db.json` whenever its mtime has changed since the last read; `persist()` stamps the mtime so an instance never needlessly re-reads its own write. Any instance now sees the latest committed state — writes from the action are visible to the render.

## Test
New `test/filerepo.test.ts`: create a job in one `FileRepo` instance and assert a second instance sees it (same for candidate portal users). 34 tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB)_