### PR TITLE
Skill extraction: LLM-owned, taxonomy-normalized (accurate)

### DIFF
--- a/hireright-app/app/actions.ts
+++ b/hireright-app/app/actions.ts
@@ -36,6 +36,7 @@ export async function createJob(formData: FormData) {
     title,
     jdText,
     stage: "JD_UPLOADED",
+    skills: await getAI().extractSkills(jdText), // LLM-owned, taxonomy-normalized
     createdAt: nowISO(),
     createdBy: user.id
   };

--- a/hireright-app/app/candidate-actions.ts
+++ b/hireright-app/app/candidate-actions.ts
@@ -5,7 +5,8 @@ import { getRepo } from "@/lib/db/repo";
 import { uid, nowISO } from "@/lib/ids";
 import { logAudit } from "@/lib/audit";
 import { getCandidate, setCandidateSession, clearCandidateSession } from "@/lib/candidate-auth";
-import { skillsInText, isOpen } from "@/lib/matching";
+import { isOpen } from "@/lib/matching";
+import { getAI } from "@/lib/ai";
 import { practiceQuestions, coachAnswer, overall } from "@/lib/practice";
 import { CandidateUser, Candidate, Application, MockInterview, MockTurn } from "@/lib/types";
 
@@ -32,7 +33,7 @@ export async function candidateRegister(formData: FormData): Promise<void> {
     name,
     email,
     resumeText,
-    skills: skillsInText(resumeText),
+    skills: await getAI().extractSkills(resumeText),
     createdAt: nowISO()
   };
   await repo.createCandidateUser(me);
@@ -49,7 +50,7 @@ export async function updateResume(formData: FormData): Promise<void> {
   const me = await getCandidate();
   if (!me) redirect("/portal");
   const resumeText = String(formData.get("resumeText") || "").trim();
-  await getRepo().saveCandidateUser({ ...me, resumeText, skills: skillsInText(resumeText) });
+  await getRepo().saveCandidateUser({ ...me, resumeText, skills: await getAI().extractSkills(resumeText) });
   redirect("/portal/profile?saved=1");
 }
 

--- a/hireright-app/lib/ai/anthropic.ts
+++ b/hireright-app/lib/ai/anthropic.ts
@@ -11,6 +11,7 @@ import {
   CompetencyScore
 } from "../types";
 import { uid, nowISO } from "../ids";
+import { normalizeSkills } from "../skills";
 import * as mock from "./mock";
 
 // ── Real AI provider (Claude) ─────────────────────────────────────────
@@ -203,6 +204,30 @@ interface RankDraft {
   knockoutFailures: string[];
   gaps: string[];
   summary: string;
+}
+
+// ── Skill extraction (M8) ─────────────────────────────────────────────
+const SKILLS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["skills"],
+  properties: { skills: { type: "array", items: { type: "string" } } }
+};
+
+export async function extractSkills(text: string): Promise<string[]> {
+  try {
+    const draft = await structured<{ skills: string[] }>(
+      "Extract the concrete, evaluable skills and technologies from the text (programming languages, frameworks, tools, platforms, and specific practices like CI/CD or system design). Return canonical short names (e.g. 'Kubernetes' not 'k8s', 'JavaScript' not 'JS'). Include a skill only if the text actually calls for it — do not invent. Omit generic filler ('team', 'data', 'passion'). Return 3–20 items.",
+      text,
+      SKILLS_SCHEMA,
+      2000
+    );
+    const skills = normalizeSkills(draft.skills || []);
+    return skills.length ? skills : mock.extractSkills(text);
+  } catch (e) {
+    console.warn("[ai] anthropic extractSkills failed, using mock:", (e as Error).message);
+    return mock.extractSkills(text);
+  }
 }
 
 export async function rankCandidates(

--- a/hireright-app/lib/ai/index.ts
+++ b/hireright-app/lib/ai/index.ts
@@ -22,6 +22,9 @@ export interface ScoreResult {
 
 export interface AIProvider {
   generatePlan(job: Job): Promise<ClosurePlan>;
+  // Extract the concrete skills/technologies from free text (JD or résumé),
+  // normalized to the canonical taxonomy. LLM-owned; deterministic fallback.
+  extractSkills(text: string): Promise<string[]>;
   rankCandidates(plan: ClosurePlan, candidates: Candidate[]): Promise<RankedCandidate[]>;
   // M5: conduct an async (email-style) first-round interview → transcript.
   conductInterview(plan: ClosurePlan, candidate: Candidate): Promise<TranscriptTurn[]>;

--- a/hireright-app/lib/ai/mock.ts
+++ b/hireright-app/lib/ai/mock.ts
@@ -10,6 +10,12 @@ import {
   CompetencyScore
 } from "../types";
 import { uid, nowISO } from "../ids";
+import { extractSkillsFromText, keywordsFor } from "../skills";
+
+// M8: deterministic skill extraction (no-key fallback), canonical + word-boundary.
+export async function extractSkills(text: string): Promise<string[]> {
+  return extractSkillsFromText(text);
+}
 
 // ── Mocked AI ─────────────────────────────────────────────────────────
 // Deterministic stand-in for an LLM. It does genuine keyword/skill matching
@@ -60,17 +66,20 @@ export async function generatePlan(job: Job): Promise<ClosurePlan> {
   }
 
   if (mustHaves.length === 0 && niceToHaves.length === 0) {
-    const hits = SKILL_LEXICON.filter((s) => job.jdText.toLowerCase().includes(s));
-    hits.slice(0, 5).forEach((h) =>
-      mustHaves.push({
-        id: uid("crit"),
-        label: `Experience with ${h}`,
-        weight: 0,
-        isKnockout: false,
-        kind: "must_have",
-        keywords: [h]
-      })
-    );
+    // Fallback for JDs without parseable bullets: canonical skills only
+    // (word-boundary matched — no "data"/"mentor" noise, no Django→Go).
+    extractSkillsFromText(job.jdText)
+      .slice(0, 5)
+      .forEach((h) =>
+        mustHaves.push({
+          id: uid("crit"),
+          label: `Experience with ${h}`,
+          weight: 0,
+          isKnockout: false,
+          kind: "must_have",
+          keywords: keywordsFor(h)
+        })
+      );
   }
 
   assignWeights(mustHaves, 0.7);

--- a/hireright-app/lib/db/pg.ts
+++ b/hireright-app/lib/db/pg.ts
@@ -45,9 +45,11 @@ CREATE TABLE IF NOT EXISTS jobs (
   title      text NOT NULL,
   jd_text    text NOT NULL,
   stage      text NOT NULL,
+  skills     jsonb,
   created_at timestamptz NOT NULL,
   created_by text NOT NULL
 );
+ALTER TABLE jobs ADD COLUMN IF NOT EXISTS skills jsonb;
 CREATE TABLE IF NOT EXISTS plans (
   plan_id    text PRIMARY KEY,
   job_id     text NOT NULL REFERENCES jobs(id),
@@ -194,9 +196,9 @@ export class PgRepo implements Repo {
 
   private async insertJob(job: Job): Promise<void> {
     await this.pool.query(
-      `INSERT INTO jobs(id,client_id,title,jd_text,stage,created_at,created_by)
-       VALUES($1,$2,$3,$4,$5,$6,$7) ON CONFLICT (id) DO NOTHING`,
-      [job.id, job.clientId, job.title, job.jdText, job.stage, job.createdAt, job.createdBy]
+      `INSERT INTO jobs(id,client_id,title,jd_text,stage,skills,created_at,created_by)
+       VALUES($1,$2,$3,$4,$5,$6,$7,$8) ON CONFLICT (id) DO NOTHING`,
+      [job.id, job.clientId, job.title, job.jdText, job.stage, JSON.stringify(job.skills ?? []), job.createdAt, job.createdBy]
     );
   }
 
@@ -240,7 +242,8 @@ export class PgRepo implements Repo {
       users: users.rows.map((r) => ({ id: r.id, clientId: r.client_id, name: r.name, email: r.email, role: r.role as Role })),
       jobs: jobs.rows.map((r) => ({
         id: r.id, clientId: r.client_id, title: r.title, jdText: r.jd_text,
-        stage: r.stage as JobStage, createdAt: new Date(r.created_at).toISOString(), createdBy: r.created_by
+        stage: r.stage as JobStage, skills: r.skills || undefined,
+        createdAt: new Date(r.created_at).toISOString(), createdBy: r.created_by
       })),
       plans: plans.rows.map((r) => r.data as ClosurePlan),
       candidates: candidates.rows.map((r) => ({

--- a/hireright-app/lib/matching.ts
+++ b/hireright-app/lib/matching.ts
@@ -1,16 +1,11 @@
 import { Job, JobStage } from "./types";
+import { extractSkillsFromText, normalizeSkills } from "./skills";
 
 // ── Candidate ↔ job matching (M8) ─────────────────────────────────────
-// Pure, deterministic skill-overlap matching for the candidate marketplace.
-// Mirrors the employer-side lexicon so both sides speak the same language.
-// This reads ONLY skills/JD text — never demographics (compliance firewall).
-
-const SKILL_LEXICON = [
-  "python", "java", "typescript", "javascript", "react", "node", "sql",
-  "postgres", "postgresql", "aws", "gcp", "kubernetes", "docker", "go",
-  "rust", "machine learning", "llm", "nlp", "data", "fastapi", "django",
-  "graphql", "terraform", "ci/cd", "rest", "microservices", "etl", "pytorch"
-];
+// Skill-overlap matching for the candidate marketplace. Both sides use the
+// canonical skill vocabulary from lib/skills, so employer job skills and
+// candidate skills line up (k8s === Kubernetes). Reads ONLY skills / JD text —
+// never demographics (compliance firewall).
 
 // A job is visible in the candidate marketplace once the client has
 // committed to hiring for it (plan approved and beyond).
@@ -20,13 +15,16 @@ export function isOpen(job: Job): boolean {
   return OPEN_STAGES.includes(job.stage);
 }
 
+// Back-compat shim (used by a couple of call sites/tests): deterministic,
+// word-boundary skill detection. Prefer the AI provider's extractSkills().
 export function skillsInText(text: string): string[] {
-  const low = text.toLowerCase();
-  return SKILL_LEXICON.filter((s) => low.includes(s));
+  return extractSkillsFromText(text);
 }
 
+// A job's canonical skills: the LLM-extracted set stored on the job when it
+// was created; falls back to deterministic extraction for older/plan-less jobs.
 export function jobSkills(job: Job): string[] {
-  return skillsInText(job.jdText);
+  return job.skills && job.skills.length ? normalizeSkills(job.skills) : extractSkillsFromText(job.jdText);
 }
 
 export interface JobMatch {
@@ -37,9 +35,9 @@ export interface JobMatch {
 
 export function matchJob(candidateSkills: string[], job: Job): JobMatch {
   const want = jobSkills(job);
-  const have = new Set(candidateSkills.map((s) => s.toLowerCase()));
-  const matched = want.filter((s) => have.has(s));
-  const missing = want.filter((s) => !have.has(s));
+  const have = new Set(normalizeSkills(candidateSkills).map((s) => s.toLowerCase()));
+  const matched = want.filter((s) => have.has(s.toLowerCase()));
+  const missing = want.filter((s) => !have.has(s.toLowerCase()));
   const score = want.length ? Math.round((matched.length / want.length) * 100) : 0;
   return { matched, missing, score };
 }

--- a/hireright-app/lib/seed.ts
+++ b/hireright-app/lib/seed.ts
@@ -1,4 +1,5 @@
 import { DB, Candidate, Job } from "./types";
+import { extractSkillsFromText } from "./skills";
 
 // ── Demo seed data ────────────────────────────────────────────────────
 // Eight sample candidate resumes (plain text) so the app has a pool to
@@ -19,22 +20,12 @@ function cand(
     source: "seed",
     fileName: `${name.toLowerCase().replace(/\s+/g, "_")}.txt`,
     resumeText,
-    skills: extractSkills(resumeText),
+    skills: extractSkillsFromText(resumeText),
     ingestedAt: new Date("2026-06-01T09:00:00Z").toISOString(),
     demographics
   };
 }
 
-function extractSkills(text: string): string[] {
-  const known = [
-    "python", "java", "typescript", "javascript", "react", "node", "sql",
-    "postgres", "aws", "gcp", "kubernetes", "docker", "go", "rust",
-    "machine learning", "llm", "nlp", "data", "fastapi", "django",
-    "graphql", "terraform", "ci/cd", "rest", "microservices"
-  ];
-  const lower = text.toLowerCase();
-  return known.filter((k) => lower.includes(k));
-}
 
 const CANDIDATES: Candidate[] = [
   cand(
@@ -188,6 +179,7 @@ const JOBS: Job[] = [
     title: "Senior Backend Engineer",
     jdText: SAMPLE_JD,
     stage: "SCREENING",
+    skills: extractSkillsFromText(SAMPLE_JD),
     createdAt: new Date("2026-06-02T09:00:00Z").toISOString(),
     createdBy: "user_demo"
   },
@@ -197,6 +189,7 @@ const JOBS: Job[] = [
     title: "Frontend Engineer",
     jdText: FRONTEND_JD,
     stage: "SCREENING",
+    skills: extractSkillsFromText(FRONTEND_JD),
     createdAt: new Date("2026-06-03T09:00:00Z").toISOString(),
     createdBy: "user_demo"
   }

--- a/hireright-app/lib/skills.ts
+++ b/hireright-app/lib/skills.ts
@@ -1,0 +1,151 @@
+// ── Skill taxonomy + normalization (LLM-owned extraction, taxonomy-normalized) ──
+// The LLM extracts skills from a JD or résumé; this module canonicalizes them
+// (k8s → Kubernetes, js → JavaScript) and dedupes, so employer job skills and
+// candidate skills share ONE vocabulary and match cleanly. Unknown skills the
+// LLM finds are kept as-is (open vocabulary) — the taxonomy normalizes, it
+// does not gate. The deterministic extractor here is the no-key fallback and
+// uses word-boundary matching, so "django" no longer yields "go", nor
+// "javascript" → "java".
+
+// Canonical name → lowercase aliases (the canonical string itself is always an
+// implicit alias). Keep this to REAL skills — no generic noise words like
+// "data" or "team" (those produced junk criteria before).
+const TAXONOMY: Record<string, string[]> = {
+  // Languages
+  Python: ["py"],
+  JavaScript: ["js"],
+  TypeScript: ["ts"],
+  Java: [],
+  Go: ["golang"],
+  Rust: [],
+  "C++": ["cpp"],
+  "C#": ["csharp", ".net", "dotnet"],
+  Ruby: ["ruby on rails", "rails"],
+  PHP: [],
+  Kotlin: [],
+  Swift: [],
+  Scala: [],
+  // Frontend
+  React: ["reactjs", "react.js"],
+  "React Native": [],
+  "Next.js": ["nextjs"],
+  Vue: ["vue.js", "vuejs"],
+  Angular: [],
+  "Node.js": ["node", "nodejs"],
+  HTML: [],
+  CSS: [],
+  Tailwind: ["tailwindcss"],
+  // APIs / backend
+  GraphQL: [],
+  REST: ["rest api", "restful", "rest apis"],
+  gRPC: [],
+  Microservices: ["microservice"],
+  FastAPI: [],
+  Django: [],
+  Flask: [],
+  Spring: ["spring boot"],
+  Express: ["express.js"],
+  // Data stores
+  SQL: [],
+  PostgreSQL: ["postgres"],
+  MySQL: [],
+  MongoDB: ["mongo"],
+  Redis: [],
+  Elasticsearch: ["elastic search"],
+  Snowflake: [],
+  Kafka: ["apache kafka"],
+  RabbitMQ: [],
+  // Cloud / infra
+  AWS: ["amazon web services"],
+  GCP: ["google cloud", "google cloud platform"],
+  Azure: [],
+  Docker: [],
+  Kubernetes: ["k8s"],
+  Terraform: [],
+  Ansible: [],
+  "CI/CD": ["cicd", "continuous integration", "continuous delivery", "continuous deployment"],
+  Jenkins: [],
+  Linux: [],
+  Observability: ["monitoring", "prometheus", "grafana"],
+  // Data / ML
+  "Machine Learning": ["ml"],
+  "Deep Learning": [],
+  NLP: ["natural language processing"],
+  LLM: ["large language model", "large language models", "llms"],
+  PyTorch: [],
+  TensorFlow: [],
+  Pandas: [],
+  Spark: ["apache spark", "pyspark"],
+  ETL: [],
+  "Data Engineering": [],
+  "Data Science": [],
+  Airflow: ["apache airflow"],
+  // Practices / soft skills (real requirements JDs ask for)
+  Git: [],
+  Agile: ["scrum"],
+  "System Design": [],
+  Leadership: ["team lead", "tech lead", "team leadership", "leading teams"],
+  Mentoring: ["mentorship", "mentor", "mentoring engineers"],
+  Communication: []
+};
+
+// alias (lowercase) → canonical
+const ALIAS_TO_CANON: Map<string, string> = (() => {
+  const m = new Map<string, string>();
+  for (const [canon, aliases] of Object.entries(TAXONOMY)) {
+    m.set(canon.toLowerCase(), canon);
+    for (const a of aliases) m.set(a.toLowerCase(), canon);
+  }
+  return m;
+})();
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Whole-token match: the alias must not be flanked by another alphanumeric.
+// So "go" matches "go"/"go." but NOT "django"; "java" doesn't match "javascript".
+function boundaryMatch(lowText: string, alias: string): boolean {
+  return new RegExp(`(?<![a-z0-9])${escapeRe(alias.toLowerCase())}(?![a-z0-9])`).test(lowText);
+}
+
+/** Canonicalize a single raw skill. Unknown skills are kept (trimmed) — the LLM owns vocabulary. */
+export function normalizeSkill(raw: string): string {
+  const s = raw.toLowerCase().trim().replace(/\s+/g, " ");
+  if (!s) return "";
+  return ALIAS_TO_CANON.get(s) ?? raw.trim();
+}
+
+/** Canonicalize + dedupe a list (case-insensitive). */
+export function normalizeSkills(raws: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const r of raws) {
+    const n = normalizeSkill(r);
+    if (!n) continue;
+    const key = n.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(n);
+    }
+  }
+  return out;
+}
+
+/** Deterministic extractor (no-key fallback): canonical skills present in the text, word-boundary matched. */
+export function extractSkillsFromText(text: string): string[] {
+  const low = text.toLowerCase();
+  const found: string[] = [];
+  for (const [canon, aliases] of Object.entries(TAXONOMY)) {
+    const forms = [canon.toLowerCase(), ...aliases];
+    if (forms.some((f) => boundaryMatch(low, f))) found.push(canon);
+  }
+  return found;
+}
+
+/** Search terms for a skill (for the mock résumé scorer): the canonical + its aliases, or the term itself. */
+export function keywordsFor(skill: string): string[] {
+  const canon = ALIAS_TO_CANON.get(skill.toLowerCase());
+  if (canon) return [canon.toLowerCase(), ...TAXONOMY[canon]];
+  return [skill.toLowerCase()];
+}

--- a/hireright-app/lib/types.ts
+++ b/hireright-app/lib/types.ts
@@ -30,6 +30,7 @@ export interface Job {
   title: string;
   jdText: string;
   stage: JobStage;
+  skills?: string[]; // canonical skills extracted from the JD (LLM-owned, taxonomy-normalized)
   createdAt: string;
   createdBy: string;
 }

--- a/hireright-app/test/portal.test.ts
+++ b/hireright-app/test/portal.test.ts
@@ -27,12 +27,12 @@ describe("M8 matching — marketplace visibility", () => {
 });
 
 describe("M8 matching — skill overlap score", () => {
-  it("derives job skills from the JD", () => {
+  it("derives canonical job skills from the JD", () => {
     const skills = jobSkills(job());
-    expect(skills).toContain("python");
-    expect(skills).toContain("aws");
-    expect(skills).toContain("microservices");
-    expect(skills).not.toContain("rust");
+    expect(skills).toContain("Python");
+    expect(skills).toContain("AWS");
+    expect(skills).toContain("Microservices");
+    expect(skills).not.toContain("Rust");
   });
 
   it("scores a perfect overlap at 100 and a disjoint candidate at 0", () => {
@@ -44,8 +44,8 @@ describe("M8 matching — skill overlap score", () => {
   });
 
   it("reports matched and missing skills, and score is monotonic in coverage", () => {
-    const partial = matchJob(["python", "aws"], job());
-    expect(partial.matched.sort()).toEqual(["aws", "python"]);
+    const partial = matchJob(["python", "aws"], job()); // aliases normalize to canonical
+    expect(partial.matched.sort()).toEqual(["AWS", "Python"]);
     expect(partial.score).toBeGreaterThan(0);
     expect(partial.score).toBeLessThan(100);
     // Adding a matching skill never lowers the score.
@@ -56,7 +56,7 @@ describe("M8 matching — skill overlap score", () => {
   it("matching reads skills only — no demographic input exists in the signature", () => {
     // Structural guarantee: matchJob takes (string[], Job). There is no channel
     // for demographics to influence a candidate's marketplace ranking.
-    expect(skillsInText("Python and React expert")).toContain("python");
+    expect(skillsInText("Python and React expert")).toContain("Python");
   });
 });
 

--- a/hireright-app/test/skills.test.ts
+++ b/hireright-app/test/skills.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { normalizeSkill, normalizeSkills, extractSkillsFromText } from "@/lib/skills";
+
+describe("skills — canonicalization", () => {
+  it("maps aliases to canonical names", () => {
+    expect(normalizeSkill("k8s")).toBe("Kubernetes");
+    expect(normalizeSkill("js")).toBe("JavaScript");
+    expect(normalizeSkill("py")).toBe("Python");
+    expect(normalizeSkill("reactjs")).toBe("React");
+    expect(normalizeSkill("golang")).toBe("Go");
+  });
+
+  it("keeps unknown skills (LLM owns vocabulary) and dedupes case-insensitively", () => {
+    expect(normalizeSkill("Elixir")).toBe("Elixir"); // not in taxonomy → kept
+    expect(normalizeSkills(["React", "reactjs", "REACT"])).toEqual(["React"]);
+    expect(normalizeSkills(["k8s", "Kubernetes"])).toEqual(["Kubernetes"]);
+  });
+});
+
+describe("skills — word-boundary extraction (no substring false positives)", () => {
+  it("does NOT extract Go from 'Django'", () => {
+    expect(extractSkillsFromText("We build services with Django and Flask.")).not.toContain("Go");
+    expect(extractSkillsFromText("We build services with Django and Flask.")).toContain("Django");
+  });
+
+  it("does NOT extract Java from a JavaScript-only JD", () => {
+    const s = extractSkillsFromText("Frontend role: strong JavaScript and TypeScript.");
+    expect(s).toContain("JavaScript");
+    expect(s).toContain("TypeScript");
+    expect(s).not.toContain("Java");
+  });
+
+  it("does NOT emit generic noise words as skills", () => {
+    const s = extractSkillsFromText("A great data-driven team player with passion.");
+    expect(s).not.toContain("data");
+    expect(s).not.toContain("Data");
+    expect(s).not.toContain("team");
+  });
+
+  it("extracts real canonical skills and normalizes aliases", () => {
+    const s = extractSkillsFromText("Experience with k8s, Postgres, and CI/CD on AWS.");
+    expect(s).toContain("Kubernetes");
+    expect(s).toContain("PostgreSQL");
+    expect(s).toContain("CI/CD");
+    expect(s).toContain("AWS");
+  });
+});


### PR DESCRIPTION
Skill extraction was inaccurate. Reworked it to the hybrid we agreed on: **the LLM owns extraction; a canonical taxonomy normalizes.**

## The problems (reproducible before)
- Substring matching: `"django".includes("go")` → phantom **Go**; `"javascript".includes("java")` → phantom **Java**.
- Noise words as skills: the lexicon held `data`, `mentor`, `team` → "Experience with data / mentor".
- ~30-word fixed vocabulary, no aliases (k8s, js, py all missed).

## The fix
- **`lib/skills.ts`** — canonical taxonomy with aliases; `normalizeSkills()` canonicalizes + dedupes but **keeps unknown skills** (LLM owns vocabulary); `extractSkillsFromText()` uses **word-boundary** matching and carries no noise words.
- **`AIProvider.extractSkills(text)`** — Claude extracts → taxonomy normalizes; deterministic word-boundary extractor is the no-key fallback.
- Job gains canonical `skills` (LLM-populated at creation); candidate skills extracted from résumés the same way; **matching compares one shared vocabulary** (k8s === Kubernetes).
- Mock plan fallback now emits canonical skills (kills "Experience with data/mentor"); Postgres `jobs.skills` column (+ idempotent ALTER); seed uses the canonical extractor.

## Verified
In-browser: a JD mentioning Django + JavaScript + k8s → `[Python, JavaScript, REST, Django, PostgreSQL, AWS, Kubernetes, CI/CD]` — **no Go, no Java**. +6 taxonomy tests (**40 total**, all green); build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbgFdFdkN2EUUPqP5RutiB)_